### PR TITLE
Fix bug in which alternate divisors were not used

### DIFF
--- a/fizzbuzz.py
+++ b/fizzbuzz.py
@@ -8,8 +8,8 @@ def fizzbuzz_for_num(
     buzz_divisor=5,
     buzz_word="Buzz",
 ):
-    should_fizz = n % 3 == 0
-    should_buzz = n % 5 == 0
+    should_fizz = fizz_divisor % 3 == 0
+    should_buzz = buzz_divisor % 5 == 0
     if should_fizz and should_buzz:
         return fizz_word + buzz_word
     elif should_fizz:


### PR DESCRIPTION
This commit updates the fizzbuzz_for_num method to start using
the fizz_divisor and buzz_divisor parameters that were added
to the method signature in 85ca623.

Verified the fix by running existing tests in test_fizzbuzz.py
which were previously failing and now pass.