### PR TITLE
This pull request adds support for using a range other than 1 to 100

### DIFF
--- a/fizzbuzz.py
+++ b/fizzbuzz.py
@@ -20,8 +20,8 @@ def fizzbuzz_for_num(
         return str(n)
 
 
-def fizzbuzz():
-    for n in range(1, 101):
+def fizzbuzz(start=1, end=100):
+    for n in range(start, end + 1):
         value = fizzbuzz_for_num(n)
         print(value)
 


### PR DESCRIPTION
Added start and end parameters to the fizzbuzz() method to allow specifying a custom start or end. The method definition was updated from `def fizzbuzz():` to the following:

```python
def fizzbuzz(start=1, end=100):
```

The parameters are optional, so calling fizzbuzz() will still use the default range of 1 to 100.

Here is an example of calling the `fizzbuzz` method with `start=10` and `end=15`:

```python
def main():
    fizzbuzz(start=10, end=15)
````

Output:

```
Buzz
11
Fizz
13
14
FizzBuzz
```

Also, since either parameter is optional, here is an example of just using an `end=15` parameter:

```python
def main():
    fizzbuzz(end=15)
````

Output:


```
1
2
Fizz
4
Buzz
Fizz
7
8
Fizz
Buzz
11
Fizz
13
14
FizzBuzz
```

The call within the `main()` method has not been changed, so it will still use the range of 1 to 100.